### PR TITLE
Add line to render list.

### DIFF
--- a/_pages/conduct.md
+++ b/_pages/conduct.md
@@ -34,6 +34,7 @@ Not all of us will agree all the time, but disagreement is no excuse for poor be
 ### Be careful in the words that you choose
 
 We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable. This includes, but is not limited to:
+
 * Violent threats or language directed against another person.
 * Discriminatory jokes and language.
 * Posting sexually explicit or violent material.


### PR DESCRIPTION
I noticed that this list wasn't rendering on the Code of Conduct page. A single hard return fixes the display issue. You can see the issue currently in prod in the "careful what words..." here: https://js.foundation/conduct/
