### PR TITLE
Updated Webpack website link

### DIFF
--- a/_projects/webpack.md
+++ b/_projects/webpack.md
@@ -1,6 +1,6 @@
 ---
 name: "webpack"
-site: "http://webpack.github.io"
+site: "http://webpack.js.org"
 logo: "webpack.svg"
 ---
 


### PR DESCRIPTION
Hi!

With Webpack 2 release its website link will change, this PR updates its link to the new one.

I am not sure if the announcement blogpost link should be updated too.

https://github.com/webpack/webpack.js.org/issues/262
