### PR TITLE
Update webpack URL to webpack.js.org

### DIFF
--- a/_projects/webpack.md
+++ b/_projects/webpack.md
@@ -1,6 +1,6 @@
 ---
 name: "webpack"
-site: "http://webpack.github.io"
+site: "https://webpack.js.org/"
 logo: "webpack.svg"
 ---
 


### PR DESCRIPTION
https://webpack.js.org/ is the current documentation for webpack 2.

Relates to https://github.com/webpack/webpack.js.org/issues/262